### PR TITLE
chore: updated ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ CMakeLists.txt.user
 .project
 *.iml
 **/build-*
+
+# ignore build files
+install/
+log/


### PR DESCRIPTION
`colcon build` creates some extra folders that we want to ignore